### PR TITLE
fix: adds info about loopable imports for TF

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -88,6 +88,11 @@
 	      "name": "templatefile() and templatestring() recursion",
 	      "version": "1.9",
 	      "url": "https://developer.hashicorp.com/terraform/language/functions/templatestring"
+      },
+      {
+        "name": "Loopable import blocks",
+        "version": "1.7",
+        "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
       }
     ]
   }

--- a/main.go
+++ b/main.go
@@ -144,6 +144,11 @@ var tools = []byte(`{
 	      "name": "templatefile() and templatestring() recursion",
 	      "version": "1.9",
 	      "url": "https://developer.hashicorp.com/terraform/language/functions/templatestring"
+      },
+      {
+        "name": "Loopable import blocks",
+        "version": "1.7",
+        "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
       }
     ]
   }

--- a/static/tools.json
+++ b/static/tools.json
@@ -88,6 +88,11 @@
 	      "name": "templatefile() and templatestring() recursion",
 	      "version": "1.9",
 	      "url": "https://developer.hashicorp.com/terraform/language/functions/templatestring"
+      },
+      {
+        "name": "Loopable import blocks",
+        "version": "1.7",
+        "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
       }
     ]
   }


### PR DESCRIPTION
## Info

* This adds missing information about loopable import block in Terraform.
* This was added in v1.7: https://github.com/hashicorp/terraform/releases/tag/v1.7.0