### PR TITLE
feat: add new features from Terraform release 1.12

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -120,6 +120,16 @@
         "name": "Loopable import blocks",
         "version": "1.7",
         "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
+      },
+      {
+        "name": "Import via identity attribute",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
+      },
+      {
+        "name": "Terraform backend OCI Object Storage",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }
     ]
   }

--- a/main.go
+++ b/main.go
@@ -184,6 +184,16 @@ var tools = []byte(`{
         "name": "Loopable import blocks",
         "version": "1.7",
         "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
+      },
+      {
+        "name": "Import via identity attribute",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
+      },
+      {
+        "name": "Terraform backend OCI Object Storage",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }
     ]
   }

--- a/static/tools.json
+++ b/static/tools.json
@@ -120,6 +120,16 @@
         "name": "Loopable import blocks",
         "version": "1.7",
         "url": "https://developer.hashicorp.com/terraform/language/v1.7.x/import#import-multiple-instances-with-for_each"
+      },
+      {
+        "name": "Import via identity attribute",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
+      },
+      {
+        "name": "Terraform backend OCI Object Storage",
+        "version": "1.12",
+        "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }
     ]
   }


### PR DESCRIPTION
Add news from [Terraform release 1.12](https://github.com/hashicorp/terraform/releases/tag/v1.12.0) to the overview namely:

- the new OCI backend
- the new option to specify import identifiers via identity attribute