### PR TITLE
fix(terraform): OCI description

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -127,7 +127,7 @@
         "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
       },
       {
-        "name": "Terraform backend OCI Object Storage",
+        "name": "Backend implementation for Oracle Cloud Infrastructure (OCI) Object Storage",
         "version": "1.12",
         "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ var tools = []byte(`{
         "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
       },
       {
-        "name": "Terraform backend OCI Object Storage",
+        "name": "Backend implementation for Oracle Cloud Infrastructure (OCI) Object Storage",
         "version": "1.12",
         "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }

--- a/static/tools.json
+++ b/static/tools.json
@@ -127,7 +127,7 @@
         "url": "https://developer.hashicorp.com/terraform/plugin/framework/resources/identity"
       },
       {
-        "name": "Terraform backend OCI Object Storage",
+        "name": "Backend implementation for Oracle Cloud Infrastructure (OCI) Object Storage",
         "version": "1.12",
         "url": "https://developer.hashicorp.com/terraform/language/backend/oci"
       }


### PR DESCRIPTION
Remove Terraform from the description, detail that OCI means ORACLE CLOUD INFRASTRUCTURE and not Open Container Initiative