### PR TITLE
add OpenTofu 1.10 S3 native state locking

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -1,6 +1,6 @@
 {
   "opentofu": {
-    "version": "1.9",
+    "version": "1.10",
     "versionURL": "https://github.com/opentofu/opentofu/releases/latest",
     "license": "MPL-2.0",
     "licenseURL": "https://github.com/opentofu/opentofu/blob/main/LICENSE",
@@ -64,6 +64,11 @@
         "name": "-exclude flag",
         "version": "1.9",
         "url": "https://opentofu.org/docs/intro/whats-new/#the--exclude-flag"
+      },
+      {
+        "name": "S3 native state locking",
+        "version": "1.10",
+        "url": "https://opentofu.org/docs/intro/whats-new/#native-s3-state-locking"
       }
     ]
   },

--- a/main.go
+++ b/main.go
@@ -64,7 +64,7 @@ var schemaData = []byte(`{
 
 var tools = []byte(`{
   "opentofu": {
-    "version": "1.9",
+    "version": "1.10",
     "versionURL": "https://github.com/opentofu/opentofu/releases/latest",
     "license": "MPL-2.0",
     "licenseURL": "https://github.com/opentofu/opentofu/blob/main/LICENSE",
@@ -128,6 +128,11 @@ var tools = []byte(`{
         "name": "-exclude flag",
         "version": "1.9",
         "url": "https://opentofu.org/docs/intro/whats-new/#the--exclude-flag"
+      },
+      {
+        "name": "S3 native state locking",
+        "version": "1.10",
+        "url": "https://opentofu.org/docs/intro/whats-new/#native-s3-state-locking"
       }
     ]
   },

--- a/static/tools.json
+++ b/static/tools.json
@@ -1,6 +1,6 @@
 {
   "opentofu": {
-    "version": "1.9",
+    "version": "1.10",
     "versionURL": "https://github.com/opentofu/opentofu/releases/latest",
     "license": "MPL-2.0",
     "licenseURL": "https://github.com/opentofu/opentofu/blob/main/LICENSE",
@@ -64,6 +64,11 @@
         "name": "-exclude flag",
         "version": "1.9",
         "url": "https://opentofu.org/docs/intro/whats-new/#the--exclude-flag"
+      },
+      {
+        "name": "S3 native state locking",
+        "version": "1.10",
+        "url": "https://opentofu.org/docs/intro/whats-new/#native-s3-state-locking"
       }
     ]
   },


### PR DESCRIPTION
Sources:

- [What's new in OpenTofu 1.10?](https://opentofu.org/docs/intro/whats-new/)
- [OpenTofu 1.10.0: A Well-Seasoned Release](https://opentofu.org/blog/opentofu-1-10-0/)
- [OpenTofu 1.10.0](https://github.com/opentofu/opentofu/releases/tag/v1.10.0)